### PR TITLE
Possible fix: not matching first character in line

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -77,7 +77,7 @@ class GotoCharacter(sublime_plugin.TextCommand):
     matches = expression.find_matches(
       self.view,
       sel.b,
-      '.(' + re.escape(character) + ')',
+      '[^'+re.escape(character)+'](' + re.escape(character) + ')',
       match_options
     )
 


### PR DESCRIPTION
Meanwhile, still allow repeat-command to go to the next character.